### PR TITLE
Configure Vercel output path

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   },
   "scripts": {
     "extension": "yarn workspace @uniswap/extension",
+    "build": "yarn workspace @uniswap/interface build:production",
     "g:build": "turbo run build --concurrency=100%",
     "g:build:storybook": "turbo run storybook:build --force --concurrency=100%",
     "g:check:deps:usage": " depcheck && turbo run check:deps:usage",

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,8 @@
       "destination": "/"
     }
   ],
+  "buildCommand": "yarn build",
+  "outputDirectory": "apps/web/build",
   "headers": [
     {
       "source": "/index.html",


### PR DESCRIPTION
## Summary
- run web build from workspace when Vercel builds
- tell Vercel where to find the build output

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_687cbc8eabc4832b8c9445a77da32423